### PR TITLE
Changing query to input

### DIFF
--- a/src/FilterQueryString.php
+++ b/src/FilterQueryString.php
@@ -45,6 +45,6 @@ trait FilterQueryString {
             return $this->unguardFilters != true ? in_array($key, $filters) : true;
         };
 
-        return array_filter(request()->query(), $filter, ARRAY_FILTER_USE_KEY) ?? [];
+        return array_filter(request()->input(), $filter, ARRAY_FILTER_USE_KEY) ?? [];
     }
 }


### PR DESCRIPTION
Using request()->input() doesn't respect the state of the $request. In other words, modifications made to the request attributes via middlewares are ignored.

This is a real use case scenario:
The Javascript framework ExtJS sends the following parameters for sorting a grid table:
`?sort=[{"property":"last_name","direction":"DESC"}]`

in order to make it compatible with this library, it should be converted to:
`sort=last_name,desc`

So instead of modifying ExtJS code, a cleaner way is to transform the query params via a custom Laravel middleware.

The problem is this (/mehradsadeghi/laravel-filter-querystring/src/FilterQueryString.php, line 51):
`return array_filter(request()->query(), $filter, ARRAY_FILTER_USE_KEY) ?? [];`

Since "query()" is being used to retrieve the request parameters, it directly reads the original URL chain, instead of the current $request state, ignoring any modification made on the fly across the request cycle.

Hope it makes sense.

Thanks.