### PR TITLE
Allow native filter classes replacement

### DIFF
--- a/src/FilterQueryString.php
+++ b/src/FilterQueryString.php
@@ -26,6 +26,14 @@ trait FilterQueryString {
 
     public function scopeFilter($query, ...$filters)
     {
+
+        if($this->customClassFilters && is_array($this->customClassFilters)) {
+
+            foreach($this->customClassFilters as $key=>$value) {
+                $this->availableFilters[$key] = $value;
+            }
+        }
+
         $filters = collect($this->getFilters($filters))->map(function ($values, $filter) {
             return $this->resolve($filter, $values);
         })->toArray();


### PR DESCRIPTION
Hi,

This allows replacing native Filter Classes directly from the model:
```
protected $customClassFilters = [
        'in' => MyCustomWhereInClause::class
    ];
```

In this example, MyCustomWhereInClause is a custom FilterClause not part of this package.