### PR TITLE
Fixing filter like bug.

### DIFF
--- a/src/Filters/WhereLikeClause.php
+++ b/src/Filters/WhereLikeClause.php
@@ -13,7 +13,7 @@ class WhereLikeClause extends BaseClause {
         $query->where(function($query) use($normalized) {
             foreach ($normalized as $field => $values) {
                 foreach ($values as $value) {
-                    $query->orWhere($field, 'like', "%$value%");
+                    $query->orWhere($field, 'like', "$value");
                 }
             }
         });


### PR DESCRIPTION
The startsWith 'a%' and endsWith '%a' LIKE operators were giving the same result.

Example, we have such data in our `users` table:
| id  |
|:---:|
|  20/10  | 
|  10/20  | 
|  11/22  | 

**When `like` query**: `https://example.com?like=20%`
Output:
| id  |
|:---:|
|  20/10  | 
|  10/20  | 

**When `like` query**: `https://example.com?like=%20`
Output:
| id  |
|:---:|
|  20/10  | 
|  10/20  | 