### PR TITLE
Ability to support filter aliases

### DIFF
--- a/models/UserFilters.php
+++ b/models/UserFilters.php
@@ -19,7 +19,9 @@ trait UserFilters {
         'username',
         'email',
         'young',
-        'old'
+        'old',
+        'alias_young' => 'filter_young',
+        'alias_old' => 'filter_old',
     ];
 
     public function young($query, $value) {
@@ -32,6 +34,24 @@ trait UserFilters {
     }
 
     public function old($query, $value) {
+
+        if($value == 1) {
+            $query->where('age', '>', 20);
+        }
+
+        return $query;
+    }
+
+    public function filter_young($query, $value) {
+
+        if($value == 1) {
+            $query->where('age', '<', 20);
+        }
+
+        return $query;
+    }
+
+    public function filter_old($query, $value) {
 
         if($value == 1) {
             $query->where('age', '>', 20);

--- a/src/FilterQueryString.php
+++ b/src/FilterQueryString.php
@@ -42,7 +42,7 @@ trait FilterQueryString {
 
             $filters = $filters ?: $this->filters ?: [];
 
-            return $this->unguardFilters != true ? in_array($key, $filters) : true;
+            return $this->unguardFilters != true ? (in_array($key, $filters) || array_key_exists($key, $filters)) : true;
         };
 
         return array_filter(request()->query(), $filter, ARRAY_FILTER_USE_KEY) ?? [];

--- a/src/Resolvings.php
+++ b/src/Resolvings.php
@@ -8,6 +8,8 @@ trait Resolvings {
     {
         if($this->isCustomFilter($filterName)) {
             return $this->resolveCustomFilter($filterName, $values);
+        } elseif ($this->isCustomFilter($this->filters[$filterName] ?? false)) {
+            return $this->resolveCustomFilter($this->filters[$filterName], $values);
         }
 
         $availableFilter = $this->availableFilters[$filterName] ?? $this->availableFilters['default'];
@@ -27,7 +29,7 @@ trait Resolvings {
 
     private function isCustomFilter($filterName)
     {
-        return method_exists($this, $filterName);
+        return $filterName && method_exists($this, $filterName);
     }
 
     private function getClosure($callable, $values)

--- a/tests/CustomFilterTest.php
+++ b/tests/CustomFilterTest.php
@@ -41,4 +41,40 @@ class CustomFilterTest extends TestCase
 
         $response->assertJsonCount(1);
     }
+
+    /** @test */
+    public function alias_young_custom_method()
+    {
+        $query = 'alias_young=1';
+
+        $response = $this->get("/?$query");
+
+        $response->assertJsonCount(0);
+
+        $query = 'alias_young=0';
+
+        $response = $this->get("/?$query");
+
+        $response->assertJsonCount(User::count());
+    }
+
+    /** @test */
+    public function alias_young_and_old_custom_method()
+    {
+        $query = 'alias_young=1&alias_old=1';
+
+        $response = $this->get("/?$query");
+
+        $response->assertJsonCount(0);
+    }
+
+    /** @test */
+    public function alias_young_custom_method_and_in()
+    {
+        $query = 'alias_young=0&in=name,mehrad';
+
+        $response = $this->get("/?$query");
+
+        $response->assertJsonCount(1);
+    }
 }


### PR DESCRIPTION
Hello!

First of all, thank you for a great package.

I'm not sure how to contribute "the right way", so I hope this PR is okay.

I've made this addition to your package, to be able to support filter aliases. Why? Because it helps me keep my code organized, and my url's "clean", e.g.:

```php
protected $filters = [
    'by' => 'filterByUsername'
];

public function filterByUsername($query, $value) {
    return $query->where('username', $value);
}
```

`https://example.com?by=dariush123`

Best regards!